### PR TITLE
Add remove duplicates issue

### DIFF
--- a/source/remove_duplicates.yml
+++ b/source/remove_duplicates.yml
@@ -1,0 +1,7 @@
+---
+level: easy
+tags: [list]
+description: |
+  If a list contains repeated elements they should be replaced with a single copy of the element. The order of the elements should not be changed.
+multicode_checks:
+  langs: [ruby, javascript, python, php]

--- a/test/battle_solutions/remove_duplicates_test.clj
+++ b/test/battle_solutions/remove_duplicates_test.clj
@@ -1,0 +1,21 @@
+(ns battle-solutions.remove-duplicates-test
+  (:require [clojure.test :refer :all]
+            [battle-asserts.test-helper :refer [assert-equal]]))
+
+(defn compress [seq]
+  (cond
+    (nil? seq) nil
+    (nil? (second seq)) seq
+    (= (first seq)
+       (first (rest seq))) (compress (rest seq))
+    :else (cons (first seq)
+                (compress (rest seq)))))
+
+(deftest test-asserts
+  (assert-equal [] (compress []))
+  (assert-equal [1] (compress [1]))
+  (assert-equal [\a \b \c] (compress "aabcc"))
+  (assert-equal [1 "foo" 2] (compress [1 "foo" 2]))
+  (assert-equal [1 2 3 2 3] (compress [1 2 3 2 3]))
+  (assert-equal [1 2 3 4 5] (compress [1 2 2 2 3 4 4 5]))
+  (assert-equal '(a b c a d e) (compress '(a a a a b c c a a d e e e e))))


### PR DESCRIPTION
### [L-99: Ninety-Nine Lisp Problems](http://www.ic.unicamp.br/~meidanis/courses/problemas-lisp/L-99_Ninety-Nine_Lisp_Problems.html)
#### P08 (**) Eliminate consecutive duplicates of list elements.
If a list contains repeated elements they should be replaced with a single copy of the element. The order of the elements should not be changed.

Example:
```clojure
(compress '(a a a a b c c a a d e e e e))
; => (a b c a d e)
```