### PR TITLE
Add a drop every N'th element from a list issue

### DIFF
--- a/source/drop_every_n_element.yml
+++ b/source/drop_every_n_element.yml
@@ -1,0 +1,10 @@
+---
+level: easy
+tags: [list]
+author:
+  github_nickname: justcxx
+
+description: Drop every N'th element from a list.
+
+multicode_checks:
+  langs: [ruby, javascript, python, php]

--- a/test/battle_solutions/drop_every_n_element_test.clj
+++ b/test/battle_solutions/drop_every_n_element_test.clj
@@ -1,0 +1,12 @@
+(ns battle-solutions.drop-every-n-element-test
+  (:require [clojure.test :refer :all]
+            [battle-asserts.test-helper :refer [assert-equal]]))
+
+(defn drop-every [n coll]
+  (keep-indexed #(if-not (= (mod (inc %1) n) 0) %2) coll))
+
+(deftest test-asserts
+  (assert-equal '(a b d e g h k) (drop-every 3 '(a b c d e f g h i k)))
+  (assert-equal [0 2 4 6 8] (drop-every 2 [0 1 2 3 4 5 6 7 8 9]))
+  (assert-equal [0 1 2 3] (drop-every 5 [0 1 2 3]))
+  (assert-equal [] (drop-every 1 [0 1 2 3 4 5 6 7])))


### PR DESCRIPTION
### [L-99: Ninety-Nine Lisp Problems](http://www.ic.unicamp.br/~meidanis/courses/problemas-lisp/L-99_Ninety-Nine_Lisp_Problems.html)
#### P16 (**) Drop every N'th element from a list.

Example:
```clojure
(drop-every 3 '(a b c d e f g h i k))
; => (a b d e g h k)
```