### PR TITLE
Add two trains meet problem

### DIFF
--- a/src/battle_asserts/issues/two_trains_meet.clj
+++ b/src/battle_asserts/issues/two_trains_meet.clj
@@ -1,0 +1,23 @@
+(ns battle-asserts.issues.two-trains-meet
+  (:require [clojure.test.check.generators :as gen]))
+
+(def level :elementary)
+
+(def description "Compute how long after their deparature two trains will meet.
+                 Assume that the trains travel between two points, along a single
+                 section of track, going in opposite directions. The function should
+                 consume the trains' speeds and the starting distance between the trains.")
+
+(defn arguments-generator []
+  (gen/tuple (gen/such-that pos? gen/nat)
+             (gen/such-that pos? gen/nat)
+             gen/pos-int))
+
+(def test-data
+  [{:expected 1 :arguments [50 50 100]}
+   {:expected 4/3 :arguments [25 50 100]}])
+
+(defn solution
+  [v-train1 v-train2 distance]
+  (/ distance (+ v-train1
+                 v-train2)))

--- a/test/battle_asserts/issues/two_trains_meet_test.clj
+++ b/test/battle_asserts/issues/two_trains_meet_test.clj
@@ -1,0 +1,14 @@
+(ns battle-asserts.issues.two-trains-meet-test
+  (:require [battle-asserts.issues.two-trains-meet :as issue]
+            [clojure.test :refer :all]
+            [clojure.test.check.clojure-test :as ct]
+            [clojure.test.check.properties :as prop]
+            [test-helper :as h]))
+
+(ct/defspec spec-solution
+  20
+  (prop/for-all [v (issue/arguments-generator)]
+                (number? (apply issue/solution v))))
+
+(deftest test-solution
+  (h/generate-tests issue/test-data issue/solution))


### PR DESCRIPTION
## [HtDP problems](http://htdp.org/2003-09-26/Problems/2.html)

### Problem 3
Develop a function that computes how long after their deparature two trains will meet. Assume that the trains travel between two points, along a single section of track, going in opposite directions. The function should consume the trains' speeds and the starting distance between the trains. Speed is distance/time.